### PR TITLE
Ian/misc

### DIFF
--- a/example/convex/_generated/server.d.ts
+++ b/example/convex/_generated/server.d.ts
@@ -22,6 +22,17 @@ import {
 import type { DataModel } from "./dataModel.js";
 
 /**
+ * Typesafe environment variables.
+ *
+ * This includes platform-provided env vars and any variables declared in
+ * `convex.config.ts`.
+ */
+type Env = {
+  readonly CONVEX_CLOUD_URL: string;
+  readonly CONVEX_SITE_URL: string;
+};
+
+/**
  * Define a query in this Convex app's public API.
  *
  * This function will be allowed to read your Convex database and will be accessible from the client.
@@ -94,6 +105,14 @@ export declare const internalAction: ActionBuilder<DataModel, "internal">;
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export declare const httpAction: HttpActionBuilder;
+
+/**
+ * Typesafe environment variables.
+ *
+ * This includes platform-provided env vars and any variables declared in
+ * `convex.config.ts`.
+ */
+export declare const env: Env;
 
 /**
  * A set of services for use within Convex query functions.

--- a/example/convex/_generated/server.js
+++ b/example/convex/_generated/server.js
@@ -91,3 +91,11 @@ export const internalAction = internalActionGeneric;
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export const httpAction = httpActionGeneric;
+
+/**
+ * Typesafe environment variables.
+ *
+ * This includes platform-provided env vars and any variables declared in
+ * `convex.config.ts`.
+ */
+export const env = process.env;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@convex-dev/workflow": "^0.4.0",
         "@convex-dev/workos": "^0.0.3",
-        "@convex-dev/workpool": "^0.4.0",
         "convex-helpers": "^0.1.111",
         "type-fest": "^5.1.0"
       },
@@ -445,6 +444,7 @@
       "resolved": "https://registry.npmjs.org/@convex-dev/workpool/-/workpool-0.4.8.tgz",
       "integrity": "sha512-ExUV3dVxUK/m2gQGB0PGuTNX/8pNtJM1T2Z+iprEhu7/4UBKM5flmu5odKBcffDnTzlGTPUQ2X+dwzy8l9T19g==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "convex": "^1.36.1",
         "convex-helpers": "^0.1.94"

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
   "dependencies": {
     "@convex-dev/workflow": "^0.4.0",
     "@convex-dev/workos": "^0.0.3",
-    "@convex-dev/workpool": "^0.4.0",
     "convex-helpers": "^0.1.111",
     "type-fest": "^5.1.0"
   }

--- a/src/component/_generated/api.ts
+++ b/src/component/_generated/api.ts
@@ -50,6 +50,5 @@ export const internal: FilterApi<
 > = anyApi as any;
 
 export const components = componentsGeneric() as unknown as {
-  eventWorkpool: import("@convex-dev/workpool/_generated/component.js").ComponentApi<"eventWorkpool">;
   backfillWorkflow: import("@convex-dev/workflow/_generated/component.js").ComponentApi<"backfillWorkflow">;
 };

--- a/src/component/backfill.test.ts
+++ b/src/component/backfill.test.ts
@@ -3,7 +3,6 @@ import { convexTest } from "convex-test";
 import { vi, describe, test, expect, beforeEach, afterEach } from "vitest";
 import { modules } from "./setup.test.js";
 import schema from "./schema.js";
-import workpool from "@convex-dev/workpool/test";
 import workflow from "@convex-dev/workflow/test";
 import { api, internal } from "./_generated/api.js";
 

--- a/src/component/backfill.test.ts
+++ b/src/component/backfill.test.ts
@@ -44,7 +44,6 @@ function makeUser(overrides: Partial<typeof defaultUser> = {}) {
 /** Initialize a convex-test instance with sub-component registrations. */
 function initConvexTest() {
   const t = convexTest(schema, modules);
-  workpool.register(t, "eventWorkpool");
   workflow.register(t, "backfillWorkflow");
   return t;
 }
@@ -224,12 +223,8 @@ describe("backfill", () => {
   });
 
   test("pagination data flows through processUsersPage", async () => {
-    const page1Users = [
-      makeUser({ id: "user_p1", email: "p1@example.com" }),
-    ];
-    const page2Users = [
-      makeUser({ id: "user_p2", email: "p2@example.com" }),
-    ];
+    const page1Users = [makeUser({ id: "user_p1", email: "p1@example.com" })];
+    const page2Users = [makeUser({ id: "user_p2", email: "p2@example.com" })];
 
     const { WorkOS } = await import("@workos-inc/node");
     const listUsersMock = vi
@@ -300,9 +295,7 @@ describe("backfill", () => {
   });
 
   test("upsert is idempotent after processUsersPage inserts", async () => {
-    const users = [
-      makeUser({ id: "user_idem", email: "idem@example.com" }),
-    ];
+    const users = [makeUser({ id: "user_idem", email: "idem@example.com" })];
 
     const { WorkOS } = await import("@workos-inc/node");
     (WorkOS as unknown as ReturnType<typeof vi.fn>).mockImplementation(

--- a/src/component/backfill.ts
+++ b/src/component/backfill.ts
@@ -10,13 +10,11 @@ import { WorkOS } from "@workos-inc/node";
 import type { FunctionHandle } from "convex/server";
 import { WorkflowManager } from "@convex-dev/workflow";
 import { vResultValidator } from "@convex-dev/workpool";
-import schema from "./schema.js";
+import { vUser } from "../validators.js";
 
 const workflow = new WorkflowManager(components.backfillWorkflow, {
   workpoolOptions: { maxParallelism: 1 },
 });
-
-const vUser = schema.tables.users.validator;
 
 export const getBackfillApiKey = internalQuery({
   args: {},
@@ -37,10 +35,7 @@ export const processUsersPage = internalAction({
   returns: v.object({
     nextCursor: v.optional(v.string()),
   }),
-  handler: async (
-    ctx,
-    args
-  ): Promise<{ nextCursor: string | undefined }> => {
+  handler: async (ctx, args): Promise<{ nextCursor: string | undefined }> => {
     const apiKey: string | null = await ctx.runQuery(
       internal.backfill.getBackfillApiKey,
       {}
@@ -124,14 +119,11 @@ export const backfillBatch = workflow.define({
     let pagesProcessed = 0;
 
     while (pagesProcessed < MAX_PAGES_PER_BATCH) {
-      const result = await step.runAction(
-        internal.backfill.processUsersPage,
-        {
-          after: cursor,
-          onEventHandle: args.onEventHandle,
-          logLevel: args.logLevel,
-        }
-      );
+      const result = await step.runAction(internal.backfill.processUsersPage, {
+        after: cursor,
+        onEventHandle: args.onEventHandle,
+        logLevel: args.logLevel,
+      });
 
       cursor = result.nextCursor;
       pagesProcessed++;

--- a/src/component/backfill.ts
+++ b/src/component/backfill.ts
@@ -8,8 +8,7 @@ import {
 import { components, internal } from "./_generated/api.js";
 import { WorkOS } from "@workos-inc/node";
 import type { FunctionHandle } from "convex/server";
-import { WorkflowManager } from "@convex-dev/workflow";
-import { vResultValidator } from "@convex-dev/workpool";
+import { vResultValidator, WorkflowManager } from "@convex-dev/workflow";
 import { vUser } from "../validators.js";
 
 const workflow = new WorkflowManager(components.backfillWorkflow, {

--- a/src/component/convex.config.ts
+++ b/src/component/convex.config.ts
@@ -1,10 +1,8 @@
 import { defineComponent } from "convex/server";
-import workpool from "@convex-dev/workpool/convex.config";
 import workflow from "@convex-dev/workflow/convex.config";
 
 const component = defineComponent("workOSAuthKit");
 
-component.use(workpool, { name: "eventWorkpool" });
 component.use(workflow, { name: "backfillWorkflow" });
 
 export default component;

--- a/src/component/lib.test.ts
+++ b/src/component/lib.test.ts
@@ -3,7 +3,6 @@ import { convexTest } from "convex-test";
 import { describe, test, expect } from "vitest";
 import { modules } from "./setup.test.js";
 import schema from "./schema.js";
-import workpool from "@convex-dev/workpool/test";
 import workflow from "@convex-dev/workflow/test";
 import { api } from "./_generated/api.js";
 
@@ -184,5 +183,62 @@ describe("onWebhookEvent", () => {
     });
     expect(dbUser?.name).toBe("Alice Jones");
     expect(dbUser?.updatedAt).toBe("2024-01-02T00:00:00.000Z");
+  });
+
+  test("user events record the user id", async () => {
+    const t = initConvexTest();
+    const user = makeUser();
+
+    await t.mutation(api.lib.onWebhookEvent, {
+      apiKey: "sk_test_123",
+      event: makeEvent("user.created", user),
+    });
+
+    const dbEvent = await t.run(async (ctx) => {
+      return ctx.db.query("events").unique();
+    });
+    expect(dbEvent?.userId).toBe(user.id);
+  });
+
+  test("events referencing a user prefer userId over the object id", async () => {
+    const t = initConvexTest();
+
+    await t.mutation(api.lib.onWebhookEvent, {
+      apiKey: "sk_test_123",
+      event: {
+        id: "event_session_created",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        event: "session.created",
+        data: {
+          object: "session",
+          id: "session_01XYZ",
+          userId: "user_01ABC",
+        },
+      },
+    });
+
+    const dbEvent = await t.run(async (ctx) => {
+      return ctx.db.query("events").unique();
+    });
+    expect(dbEvent?.userId).toBe("user_01ABC");
+  });
+
+  test("events without a usable id record no userId", async () => {
+    const t = initConvexTest();
+
+    await t.mutation(api.lib.onWebhookEvent, {
+      apiKey: "sk_test_123",
+      event: {
+        id: "event_connection_activated",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        event: "connection.activated",
+        data: { object: "connection", id: null },
+      },
+    });
+
+    const dbEvent = await t.run(async (ctx) => {
+      return ctx.db.query("events").unique();
+    });
+    expect(dbEvent?.userId).toBeUndefined();
   });
 });

--- a/src/component/lib.test.ts
+++ b/src/component/lib.test.ts
@@ -46,7 +46,6 @@ function makeEvent(
 /** Initialize a convex-test instance with sub-component registrations. */
 function initConvexTest() {
   const t = convexTest(schema, modules);
-  workpool.register(t, "eventWorkpool");
   workflow.register(t, "backfillWorkflow");
   return t;
 }

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -14,6 +14,7 @@ import type { FunctionHandle } from "convex/server";
 import { Workpool } from "@convex-dev/workpool";
 import { vUser } from "../validators.js";
 import { parse } from "convex-helpers/validators";
+import type { Doc } from "./_generated/dataModel.js";
 
 const eventWorkpool = new Workpool(components.eventWorkpool, {
   maxParallelism: 1,
@@ -203,7 +204,7 @@ export const getAuthUser = query({
       .query("users")
       .withIndex("id", (q) => q.eq("id", args.id))
       .unique();
-    return user ? withoutSystemFields(user) : null;
+    return publicUser(user);
   },
 });
 
@@ -217,6 +218,11 @@ export const getAuthUserByExternalId = query({
       .query("users")
       .withIndex("externalId", (q) => q.eq("externalId", args.externalId))
       .unique();
-    return user ? withoutSystemFields(user) : null;
+    return publicUser(user);
   },
 });
+
+function publicUser(user: Doc<"users"> | null): Infer<typeof vUser> | null {
+  if (!user) return null;
+  return withoutSystemFields(user);
+}

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -39,6 +39,13 @@ async function processEventHandler(
   if (args.logLevel === "DEBUG") {
     console.log("processing event", args.event);
   }
+  const event = args.event as WorkOSEvent;
+  const userId =
+    "id" in args.event.data
+      ? args.event.data.id
+      : "userId" in args.event.data
+        ? args.event.data.userId
+        : undefined;
   const dbEvent = await ctx.db
     .query("events")
     .withIndex("eventId", (q) => q.eq("eventId", args.event.id))
@@ -48,6 +55,8 @@ async function processEventHandler(
     return;
   }
   await ctx.db.insert("events", {
+    // can be used in the future to delete events related to a user
+    userId,
     eventId: args.event.id,
     event: args.event.event,
     updatedAt: args.event.data.updatedAt as string | undefined,

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -8,7 +8,7 @@ import {
 } from "./_generated/server.js";
 import type { MutationCtx } from "./_generated/server.js";
 import { components, internal } from "./_generated/api.js";
-import { omit, withoutSystemFields } from "convex-helpers";
+import { withoutSystemFields } from "convex-helpers";
 import { WorkOS, type Event as WorkOSEvent } from "@workos-inc/node";
 import type { FunctionHandle } from "convex/server";
 import { Workpool } from "@convex-dev/workpool";
@@ -61,40 +61,44 @@ async function processEventHandler(
     event: args.event.event,
     updatedAt: args.event.data.updatedAt as string | undefined,
   });
-  const event = args.event as WorkOSEvent;
+  let eventForCallback = event.event;
   switch (event.event) {
-    case "user.created": {
-      const data = omit(event.data, ["object"]);
+    case "user.created":
+    case "user.updated": {
+      const data = parse(vUser, event.data);
       const existingUser = await ctx.db
         .query("users")
         .withIndex("id", (q) => q.eq("id", data.id))
         .unique();
-      if (existingUser) {
-        console.warn("user already exists", data.id);
-        return;
-      }
-      await ctx.db.insert("users", data);
-      break;
-    }
-    case "user.updated": {
-      const data = parse(vUser, event.data);
-      const user = await ctx.db
-        .query("users")
-        .withIndex("id", (q) => q.eq("id", data.id))
-        .unique();
-      if (!user) {
-        // The update may have been delivered before the create; the
-        // payload is the full user object, so insert it. The create
-        // no-ops on arrival via the existing-user guard above.
-        console.warn("user not found for update, inserting", data.id);
+      if (!existingUser) {
+        const deletedUser = await ctx.db
+          .query("deletedUsers")
+          .withIndex("id", (q) => q.eq("id", data.id))
+          .unique();
+        if (deletedUser) {
+          console.warn("user already deleted, skipping", event.event, data.id);
+          return;
+        }
         await ctx.db.insert("users", data);
-        break;
+        if (event.event === "user.updated") {
+          // The update may have been delivered before the create; the
+          // payload is the full user object, so insert it. The create
+          // no-ops on arrival via the existing-user guard.
+          console.warn("user not found for update, inserting", data.id);
+          eventForCallback = "user.created";
+        }
+      } else {
+        if (event.event === "user.created") {
+          console.warn("user already exists", data.id);
+          // Note: we skip notifying the user's callback here, but we
+          // should have called them with "user.created" for the update.
+          return;
+        } else if (existingUser.updatedAt >= data.updatedAt) {
+          console.warn(`user already updated for event ${event.id}, skipping`);
+          return;
+        }
+        await ctx.db.patch("users", existingUser._id, data);
       }
-      if (user.updatedAt >= data.updatedAt) {
-        console.warn(`user already updated for event ${event.id}, skipping`);
-        return;
-      }
-      await ctx.db.patch("users", user._id, data);
       break;
     }
     case "user.deleted": {
@@ -104,16 +108,19 @@ async function processEventHandler(
         .withIndex("id", (q) => q.eq("id", data.id))
         .unique();
       if (!user) {
-        console.warn("user not found", data.id);
+        console.warn("user not found, skipping deletion", data.id);
         return;
       }
       await ctx.db.delete("users", user._id);
+      await ctx.db.insert("deletedUsers", {
+        id: user.id,
+      });
       break;
     }
   }
   if (args.onEventHandle) {
     await ctx.runMutation(args.onEventHandle as FunctionHandle<"mutation">, {
-      event: args.event.event,
+      event: eventForCallback,
       data: args.event.data,
     });
   }

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -28,12 +28,11 @@ async function processEventHandler(
     console.log("processing event", args.event);
   }
   const event = args.event as WorkOSEvent;
-  const userId =
-    "id" in args.event.data
-      ? args.event.data.id
-      : "userId" in args.event.data
-        ? args.event.data.userId
-        : undefined;
+  // Best-effort: user-scoped events either reference the user as `userId` or
+  // are the user object itself (`id`). Events for other object types can land
+  // here too, but this is only used to find events related to a given user.
+  const eventUserId = args.event.data.userId ?? args.event.data.id;
+  const userId = typeof eventUserId === "string" ? eventUserId : undefined;
   const dbEvent = await ctx.db
     .query("events")
     .withIndex("eventId", (q) => q.eq("eventId", args.event.id))

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -1,24 +1,12 @@
-import { type Infer, v } from "convex/values";
-import {
-  internalAction,
-  internalMutation,
-  internalQuery,
-  mutation,
-  query,
-} from "./_generated/server.js";
-import type { MutationCtx } from "./_generated/server.js";
-import { components, internal } from "./_generated/api.js";
+import { type Event as WorkOSEvent } from "@workos-inc/node";
 import { withoutSystemFields } from "convex-helpers";
-import { WorkOS, type Event as WorkOSEvent } from "@workos-inc/node";
-import type { FunctionHandle } from "convex/server";
-import { Workpool } from "@convex-dev/workpool";
-import { vUser } from "../validators.js";
 import { parse } from "convex-helpers/validators";
+import type { FunctionHandle } from "convex/server";
+import { type Infer, v } from "convex/values";
+import { vUser } from "../validators.js";
 import type { Doc } from "./_generated/dataModel.js";
-
-const eventWorkpool = new Workpool(components.eventWorkpool, {
-  maxParallelism: 1,
-});
+import type { MutationCtx } from "./_generated/server.js";
+import { mutation, query } from "./_generated/server.js";
 
 export const vEvent = v.object({
   id: v.string(),
@@ -140,73 +128,6 @@ export const onWebhookEvent = mutation({
     // event types can be processed inline.
     await processEventHandler(ctx, args);
     return null;
-  },
-});
-
-export const getCursor = internalQuery({
-  args: {},
-  returns: v.union(v.string(), v.null()),
-  handler: async (ctx) => {
-    const lastProcessedEvent = await ctx.db
-      .query("events")
-      .order("desc")
-      .first();
-    return lastProcessedEvent?.eventId;
-  },
-});
-
-export const updateEvents = internalAction({
-  args: {
-    apiKey: v.string(),
-    onEventHandle: v.optional(v.string()),
-    eventTypes: v.optional(v.array(v.string())),
-    logLevel: v.optional(v.literal("DEBUG")),
-  },
-  handler: async (ctx, args) => {
-    // Cancel other pending workpool jobs since this run will
-    // process all available events from the WorkOS API.
-    await eventWorkpool.cancelAll(ctx);
-    const workos = new WorkOS(args.apiKey);
-    const cursor = await ctx.runQuery(internal.lib.getCursor);
-    let nextCursor = cursor ?? undefined;
-    const eventTypes = [
-      "user.created" as const,
-      "user.updated" as const,
-      "user.deleted" as const,
-      ...((args.eventTypes as WorkOSEvent["event"][]) ?? []),
-    ];
-    // No cursor should mean we haven't handled any events - set
-    // a start time of 5 minutes ago
-    let rangeStart = nextCursor
-      ? undefined
-      : new Date(Date.now() - 1000 * 60 * 5).toISOString();
-    do {
-      const { data, listMetadata } = await workos.events.listEvents({
-        events: eventTypes,
-        after: nextCursor,
-        rangeStart,
-      });
-      for (const event of data) {
-        await ctx.runMutation(internal.lib.processEvent, {
-          event: parse(vEvent, event),
-          logLevel: args.logLevel,
-          onEventHandle: args.onEventHandle,
-        });
-      }
-      nextCursor = listMetadata.after ?? undefined;
-      rangeStart = undefined;
-    } while (nextCursor);
-  },
-});
-
-export const processEvent = internalMutation({
-  args: {
-    event: vEvent,
-    logLevel: v.optional(v.literal("DEBUG")),
-    onEventHandle: v.optional(v.string()),
-  },
-  handler: async (ctx, args) => {
-    await processEventHandler(ctx, args);
   },
 });
 

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -12,7 +12,7 @@ import { omit, withoutSystemFields } from "convex-helpers";
 import { WorkOS, type Event as WorkOSEvent } from "@workos-inc/node";
 import type { FunctionHandle } from "convex/server";
 import { Workpool } from "@convex-dev/workpool";
-import schema from "./schema.js";
+import { vUser } from "../validators.js";
 import { parse } from "convex-helpers/validators";
 
 const eventWorkpool = new Workpool(components.eventWorkpool, {
@@ -67,7 +67,7 @@ async function processEventHandler(
       break;
     }
     case "user.updated": {
-      const data = omit(event.data, ["object"]);
+      const data = parse(vUser, event.data);
       const user = await ctx.db
         .query("users")
         .withIndex("id", (q) => q.eq("id", data.id))
@@ -88,7 +88,7 @@ async function processEventHandler(
       break;
     }
     case "user.deleted": {
-      const data = omit(event.data, ["object"]);
+      const data = parse(vUser, event.data);
       const user = await ctx.db
         .query("users")
         .withIndex("id", (q) => q.eq("id", data.id))
@@ -197,7 +197,7 @@ export const getAuthUser = query({
   args: {
     id: v.string(),
   },
-  returns: v.union(schema.tables.users.validator, v.null()),
+  returns: v.union(vUser, v.null()),
   handler: async (ctx, args) => {
     const user = await ctx.db
       .query("users")
@@ -211,7 +211,7 @@ export const getAuthUserByExternalId = query({
   args: {
     externalId: v.string(),
   },
-  returns: v.union(schema.tables.users.validator, v.null()),
+  returns: v.union(vUser, v.null()),
   handler: async (ctx, args) => {
     const user = await ctx.db
       .query("users")

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -7,6 +7,7 @@ export default defineSchema({
     eventId: v.string(),
     event: v.string(),
     updatedAt: v.optional(v.string()),
+    userId: v.optional(v.string()),
   }).index("eventId", ["eventId"]),
   backfillState: defineTable({
     apiKey: v.string(),

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -1,5 +1,6 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
+import { vUser } from "../validators.js";
 
 export default defineSchema({
   events: defineTable({
@@ -10,19 +11,7 @@ export default defineSchema({
   backfillState: defineTable({
     apiKey: v.string(),
   }),
-  users: defineTable({
-    id: v.string(),
-    email: v.string(),
-    name: v.optional(v.union(v.null(), v.string())),
-    firstName: v.optional(v.union(v.null(), v.string())),
-    lastName: v.optional(v.union(v.null(), v.string())),
-    emailVerified: v.boolean(),
-    profilePictureUrl: v.optional(v.union(v.null(), v.string())),
-    lastSignInAt: v.optional(v.union(v.null(), v.string())),
-    externalId: v.optional(v.union(v.null(), v.string())),
-    metadata: v.record(v.string(), v.any()),
-    locale: v.optional(v.union(v.null(), v.string())),
-    createdAt: v.string(),
-    updatedAt: v.string(),
-  }).index("id", ["id"]).index("externalId", ["externalId"]),
+  users: defineTable(vUser)
+    .index("id", ["id"])
+    .index("externalId", ["externalId"]),
 });

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -15,4 +15,7 @@ export default defineSchema({
   users: defineTable(vUser)
     .index("id", ["id"])
     .index("externalId", ["externalId"]),
+  deletedUsers: defineTable({
+    id: v.string(),
+  }).index("id", ["id"]),
 });

--- a/src/test.ts
+++ b/src/test.ts
@@ -15,7 +15,6 @@ function register(
   name: string = "workOSAuthKit"
 ) {
   t.registerComponent(name, schema, modules);
-  workpool.register(t, `${name}/eventWorkpool`);
   workflow.register(t, `${name}/backfillWorkflow`);
 }
 export default { register, schema, modules };

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,6 +1,5 @@
 import type { TestConvex } from "convex-test";
 import type { GenericSchema, SchemaDefinition } from "convex/server";
-import workpool from "@convex-dev/workpool/test";
 import workflow from "@convex-dev/workflow/test";
 import schema from "./component/schema.js";
 const modules = import.meta.glob("./component/**/*.ts");

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,0 +1,17 @@
+import { v } from "convex/values";
+
+export const vUser = v.object({
+  id: v.string(),
+  email: v.string(),
+  name: v.optional(v.union(v.null(), v.string())),
+  firstName: v.optional(v.union(v.null(), v.string())),
+  lastName: v.optional(v.union(v.null(), v.string())),
+  emailVerified: v.boolean(),
+  profilePictureUrl: v.optional(v.union(v.null(), v.string())),
+  lastSignInAt: v.optional(v.union(v.null(), v.string())),
+  externalId: v.optional(v.union(v.null(), v.string())),
+  metadata: v.record(v.string(), v.any()),
+  locale: v.optional(v.union(v.null(), v.string())),
+  createdAt: v.string(),
+  updatedAt: v.string(),
+});


### PR DESCRIPTION
Follow-up to #73 

You can review as separate commits, main changes are:

1. Drop the event listing now that we're all-in on webhooks
2. Move the user validator out to a shared file
3. Capture the userId in events so we can (in the future) offer an API to delete events by associated user
4. Add user tombstones in a new "deletedUsers" table, so we can avoid handling create/update events for deleted users. In the future we can have an API / async worker to clean up deleted users after some period of time (>3 days would be safest, since WorkOS will try that long to deliver an old webhook event)

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
